### PR TITLE
Fix Twine logger

### DIFF
--- a/index.twee
+++ b/index.twee
@@ -185,7 +185,7 @@ window.runMatch = function () {
   if (State.variables.logRallyDetailed) levels.add("rallyDetailed");
   if (State.variables.logDebug) levels.add("debug");
 
-  const logger = new window.engine.ConsoleLogger(levels, "ru");
+  const logger = new window.engine.HtmlLogger(levels, "ru");
 
   const playerA = Object.assign({}, State.variables.player);
   const playerB = Object.assign({}, State.variables.opponent);


### PR DESCRIPTION
## Summary
- use `HtmlLogger` for match logging so `toHtml()` exists

## Testing
- `./tweego/tweego -o /tmp/index.html index.twee` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686c1a734588832bad4c8efb4bbb0306